### PR TITLE
packagesets: add falter-berlin-ssid-changer

### DIFF
--- a/packageset/1.2.1/notunnel.txt
+++ b/packageset/1.2.1/notunnel.txt
@@ -32,6 +32,7 @@ falter-common
 falter-common-olsr
 falter-policyrouting
 falter-profiles
+falter-berlin-ssid-changer
 # allow upgrade from one type to another
 falter-berlin-tunneldigger
 

--- a/packageset/1.2.1/tunneldigger.txt
+++ b/packageset/1.2.1/tunneldigger.txt
@@ -33,6 +33,7 @@ falter-common
 falter-common-olsr
 falter-policyrouting
 falter-profiles
+falter-berlin-ssid-changer
 
 # GUI-basics
 uhttpd


### PR DESCRIPTION
As we've created ssid-changer package with https://github.com/Freifunk-Spalter/packages/pull/189 we still need to add this into the images.

```
The ssid-changer changes ssids if a node cannot reach the
internet anymore.

Signed-off-by: Martin Hübner <martin.hubner@web.de>
```