### PR TITLE
scripts: add a script to update the olsrd init scripts

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -318,6 +318,7 @@ function generate_embedded_files {
     ../../scripts/03-luci-footer.sh $FREIFUNK_RELEASE $TARGET $SUBTARGET $FALTERBRANCH $FREIFUNK_REVISION
     export REPO # export repo line to inject into images. contains whitespace...
     ../../scripts/04-include-falter-feed.sh
+    ../../scripts/05-olsrd-init-for-21-02-0.sh $FALTERBRANCH
 }
 
 function start_build {

--- a/scripts/05-olsrd-init-for-21-02-0.sh
+++ b/scripts/05-olsrd-init-for-21-02-0.sh
@@ -1,0 +1,11 @@
+OPENWRT_BASE="$1"
+
+[ "$OPENWRT_BASE" != "21.02.0" ] && exit
+
+OPENWRT_ROUTING_COMMITID="1fcda9dfa893ed5b06ce71f36f454cfec11092e5"
+SCRIPTPATH=$(dirname $(readlink -f "$0"))
+INITDIR="$SCRIPTPATH/../embedded-files/etc/init.d"
+
+mkdir -p $INITDIR
+wget -O $INITDIR/olsrd https://raw.githubusercontent.com/openwrt/routing/${OPENWRT_ROUTING_COMMITID}/olsrd/files/olsrd4.init
+wget -O $INITDIR/olsrd6 https://raw.githubusercontent.com/openwrt/routing/${OPENWRT_ROUTING_COMMITID}/olsrd/files/olsrd6.init


### PR DESCRIPTION
use the upstream olsrd and olsrd6 init scripts.  The init scripts
delivered with 21.02.0 are problematic and the changes needed have
been incorperated upstream.  This script will execute when the
OPENWRT_BASE is set to "21.02.0".  For all other versions, the package
default will be used.

The relevant commit it to get the updated init scripts is:
1fcda9dfa893ed5b06ce71f36f454cfec11092e5

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>