### PR TITLE
scripts: ensure olsrd(6) init scripts are executable

### DIFF
--- a/scripts/05-olsrd-init-for-21-02-0.sh
+++ b/scripts/05-olsrd-init-for-21-02-0.sh
@@ -9,3 +9,5 @@ INITDIR="$SCRIPTPATH/../embedded-files/etc/init.d"
 mkdir -p $INITDIR
 wget -O $INITDIR/olsrd https://raw.githubusercontent.com/openwrt/routing/${OPENWRT_ROUTING_COMMITID}/olsrd/files/olsrd4.init
 wget -O $INITDIR/olsrd6 https://raw.githubusercontent.com/openwrt/routing/${OPENWRT_ROUTING_COMMITID}/olsrd/files/olsrd6.init
+chmod +x $INITDIR/olsrd
+chmod +x $INITDIR/olsrd6


### PR DESCRIPTION
add a "chmod +x" for both the olsrd and olsrd6 init scripts
in the 05-olsrd-init-for-21-02-0.sh script

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>