### PR TITLE
remove batman, add autoupdate

### DIFF
--- a/packageset/21.02/backbone.txt
+++ b/packageset/21.02/backbone.txt
@@ -72,12 +72,6 @@ olsrd-mod-txtinfo
 olsrd-mod-nameservice
 kmod-ipip
 
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
-
 # Statistics
 luci-app-statistics
 collectd

--- a/packageset/21.02/notunnel.txt
+++ b/packageset/21.02/notunnel.txt
@@ -71,6 +71,12 @@ luci-i18n-ffwizard-falter-en
 luci-i18n-falter-policyrouting-de
 luci-i18n-falter-policyrouting-en
 
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
+
 # OLSR
 olsrd
 olsrd-utils

--- a/packageset/21.02/notunnel.txt
+++ b/packageset/21.02/notunnel.txt
@@ -81,12 +81,6 @@ olsrd-mod-txtinfo
 olsrd-mod-nameservice
 kmod-ipip
 
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
-
 # Uplink
 falter-berlin-uplink-notunnel
 

--- a/packageset/21.02/tunneldigger.txt
+++ b/packageset/21.02/tunneldigger.txt
@@ -80,12 +80,6 @@ olsrd-mod-txtinfo
 olsrd-mod-nameservice
 kmod-ipip
 
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
-
 # Uplink
 falter-berlin-uplink-tunnelberlin
 

--- a/packageset/21.02/tunneldigger.txt
+++ b/packageset/21.02/tunneldigger.txt
@@ -70,6 +70,12 @@ luci-i18n-ffwizard-falter-en
 luci-i18n-falter-policyrouting-de
 luci-i18n-falter-policyrouting-en
 
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
+
 # OLSR
 olsrd
 olsrd-utils


### PR DESCRIPTION
This PR prepares a new release of the firmware based on the new OpenWrt-Version 21.02.2. It tackles two aspects: more free flash on 8MB-Devices and automatic updates.