### PR TITLE
packagelists: adjust snapshot-lists for fw4

### DIFF
--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -68,12 +68,6 @@ olsrd-mod-nameservice
 olsrd-mod-watchdog
 kmod-ipip
 
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
-
 # Statistics
 luci-app-statistics
 collectd

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -22,7 +22,8 @@ ethtool
 #dnsmasq is already provided via dnsmasq-full
 -dnsmasq
 qos-scripts
-firewall
+firewall4
+iptables-nft
 iwinfo
 libiwinfo-lua
 tcpdump-mini
@@ -80,12 +81,6 @@ olsrd-mod-txtinfo
 olsrd-mod-nameservice
 olsrd-mod-watchdog
 kmod-ipip
-
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
 
 # Uplink
 falter-berlin-uplink-notunnel

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -23,7 +23,8 @@ ethtool
 #dnsmasq is already provided via dnsmasq-full
 -dnsmasq
 qos-scripts
-firewall
+firewall4
+iptables-nft
 iwinfo
 libiwinfo-lua
 tcpdump-mini
@@ -79,12 +80,6 @@ olsrd-mod-txtinfo
 olsrd-mod-nameservice
 olsrd-mod-watchdog
 kmod-ipip
-
-# BATMAN
-batctl-full
--batctl-tiny
-kmod-batman-adv
-alfred
 
 # Uplink
 falter-berlin-uplink-tunnelberlin


### PR DESCRIPTION
Since some time firewall4 is the standard instead of abandoned firewall3.

Signed-off-by: Martin Hübner <martin.hubner@web.de>