### PR TITLE
packagelists: tidy up the lists for 1.2.2

### DIFF
--- a/packageset/1.2.2/backbone.txt
+++ b/packageset/1.2.2/backbone.txt
@@ -75,9 +75,11 @@ kmod-ipip
 # Statistics
 luci-app-statistics
 collectd
+collectd-mod-cpu
 collectd-mod-dhcpleases
 collectd-mod-interface
 collectd-mod-iwinfo
+collectd-mod-load
 collectd-mod-network
 collectd-mod-olsrd
 collectd-mod-rrdtool

--- a/packageset/1.2.2/notunnel.txt
+++ b/packageset/1.2.2/notunnel.txt
@@ -93,9 +93,11 @@ falter-berlin-uplink-notunnel
 # Statistics
 luci-app-statistics
 collectd
+collectd-mod-cpu
 collectd-mod-dhcpleases
 collectd-mod-interface
 collectd-mod-iwinfo
+collectd-mod-load
 collectd-mod-network
 collectd-mod-olsrd
 collectd-mod-rrdtool

--- a/packageset/1.2.2/tunneldigger.txt
+++ b/packageset/1.2.2/tunneldigger.txt
@@ -11,7 +11,6 @@ falter-berlin-olsrd-defaults
 falter-berlin-statistics-defaults
 falter-berlin-system-defaults
 falter-berlin-uhttpd-defaults
-falter-profiles
 
 # Common
 mtr
@@ -52,7 +51,7 @@ luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
 
-# GUI transaltion stuff
+# GUI translation stuff
 luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-firewall-de


### PR DESCRIPTION
There were some doubled packages and some minor packages for
collectd missing.

Signed-off-by: Martin Hübner <martin.hubner@web.de>