### PR TITLE
packagelists: add version 1.3.0

### DIFF
--- a/packageset/1.3.0/backbone.txt
+++ b/packageset/1.3.0/backbone.txt
@@ -1,0 +1,88 @@
+-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+
+# Common
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+
+# falter Common
+falter-common
+falter-common-olsr
+falter-berlin-tunneldigger
+
+# Utils
+tcpdump-mini
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+iwinfo
+libiwinfo-lua
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI transalation stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# OLSR
+olsrd
+olsrd-utils
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+kmod-ipip
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-cpu
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-load
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory

--- a/packageset/1.3.0/notunnel.txt
+++ b/packageset/1.3.0/notunnel.txt
@@ -1,0 +1,108 @@
+-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-firewall-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-migration
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+
+# Common
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+qos-scripts
+firewall4
+iptables-nft
+iwinfo
+libiwinfo-lua
+tcpdump-mini
+
+# falter Common
+falter-common
+falter-common-olsr
+falter-policyrouting
+falter-profiles
+# allow upgrade from one type to another
+falter-berlin-tunneldigger
+falter-berlin-ssid-changer
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-app-ffwizard-falter
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-firewall
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI translation stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-firewall-de
+luci-i18n-firewall-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
+
+# OLSR
+olsrd
+olsrd-utils
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+kmod-ipip
+
+# Uplink
+falter-berlin-uplink-notunnel
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-cpu
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-load
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory

--- a/packageset/1.3.0/tunneldigger.txt
+++ b/packageset/1.3.0/tunneldigger.txt
@@ -1,0 +1,108 @@
+#-wpad-mini
+#wpad
+
+# Defaults
+falter-berlin-dhcp-defaults
+falter-berlin-firewall-defaults
+falter-berlin-freifunk-defaults
+falter-berlin-migration
+falter-berlin-network-defaults
+falter-berlin-olsrd-defaults
+falter-berlin-statistics-defaults
+falter-berlin-system-defaults
+falter-berlin-uhttpd-defaults
+falter-profiles
+
+# Common
+mtr
+ip
+iperf3
+tmux
+vnstat
+ethtool
+#dnsmasq is already provided via dnsmasq-full
+-dnsmasq
+qos-scripts
+firewall4
+iptables-nft
+iwinfo
+libiwinfo-lua
+tcpdump-mini
+
+# falter Common
+falter-common
+falter-common-olsr
+falter-policyrouting
+falter-profiles
+falter-berlin-tunneldigger
+falter-berlin-ssid-changer
+
+# GUI-basics
+uhttpd
+uhttpd-mod-ubus
+luci
+luci-ssl
+luci-app-ffwizard-falter
+luci-mod-falter
+luci-app-olsr
+luci-app-opkg
+luci-app-firewall
+luci-app-olsr-services
+luci-app-falter-owm
+luci-app-falter-owm-ant
+luci-app-falter-owm-cmd
+luci-app-falter-owm-gui
+luci-proto-ppp
+luci-theme-bootstrap
+
+# GUI translation stuff
+luci-i18n-base-de
+luci-i18n-base-en
+luci-i18n-firewall-de
+luci-i18n-firewall-en
+luci-i18n-olsr-de
+luci-i18n-olsr-en
+luci-i18n-opkg-de
+luci-i18n-opkg-en
+luci-i18n-statistics-de
+luci-i18n-statistics-en
+luci-i18n-falter-de
+luci-i18n-falter-en
+luci-i18n-ffwizard-falter-de
+luci-i18n-ffwizard-falter-en
+luci-i18n-falter-policyrouting-de
+luci-i18n-falter-policyrouting-en
+
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
+
+# OLSR
+olsrd
+olsrd-utils
+olsrd-mod-arprefresh
+olsrd-mod-dyn-gw
+olsrd-mod-jsoninfo
+olsrd-mod-txtinfo
+olsrd-mod-nameservice
+kmod-ipip
+
+# Uplink
+falter-berlin-uplink-tunnelberlin
+
+# Statistics
+luci-app-statistics
+collectd
+collectd-mod-cpu
+collectd-mod-dhcpleases
+collectd-mod-interface
+collectd-mod-iwinfo
+collectd-mod-load
+collectd-mod-network
+collectd-mod-olsrd
+collectd-mod-rrdtool
+collectd-mod-ping
+collectd-mod-uptime
+collectd-mod-memory


### PR DESCRIPTION
Add a packagelist for the OpenWrt-22.03-based falter-1.3.0.

Signed-off-by: Martin Hübner <martin.hubner@web.de>