### PR TITLE
build_falter: better error checking

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -3,10 +3,13 @@
 # shellcheck disable=SC2155
 # shellcheck disable=SC1091
 
-# do not use 'set -e'. It will abort a whole build if, i.e. the
-# memory of a single 4MB-Device exceeds.
-# set -e
+# use of 'set -o errexit' could abort a whole build if, i.e. the
+# memory of a single 4MB-Device exceeds. This should be used with
+# care.
+set -o errexit
 set -o pipefail
+# we use unset variables in if-conditions, i.e. line 390. Thus not activating
+# set -o nounset
 
 REALPATH_SCRIPT=$(realpath "$0")
 export BUILTER_DIR=$(dirname "$REALPATH_SCRIPT")
@@ -30,7 +33,8 @@ export OVERRIDE_TO_8MiB="
     ubnt_unifiac-mesh
 "
 # script dependencies (Debian/Ubuntu-centric)
-SCRIPT_DEPENDS="awk curl gawk grep git gettext printf python3 rsync sed unzip wget sqlite3"
+SCRIPT_DEPENDS="awk bzip2 curl flex gawk grep git gettext make patch printf \
+python3 rsync sed unzip wget xgettext xsltproc sqlite3"
 
 source ./lib.bash
 
@@ -293,7 +297,11 @@ function start_build {
 
             modify_packagelist "$profile"
 
+            # deactivate exits on error for imagebuilder only
+            set +o errexit
             make image PROFILE="$profile" PACKAGES="$PACKAGE_SET_DEVICE" FILES="../../embedded-files/" EXTRA_IMAGE_NAME="freifunk-falter-${FREIFUNK_RELEASE}"
+            set -o errexit
+
             PACKAGE_SET_DEVICE="" # empty packageset for use with next wave1-device
             echo "finished."
         done
@@ -302,7 +310,10 @@ function start_build {
 
         modify_packagelist "$DEVICE"
 
+        set +o errexit
         make image PROFILE="$DEVICE" PACKAGES="$PACKAGE_SET_DEVICE" FILES="../../embedded-files/" EXTRA_IMAGE_NAME="freifunk-falter-${FREIFUNK_RELEASE}"
+        set -o errexit
+
         PACKAGE_SET_DEVICE=""
     fi
     # move binaries into central firmware-dir, sort them for packagesets, there was given one.

--- a/build_falter
+++ b/build_falter
@@ -191,6 +191,7 @@ if ! curl --silent --fail "$FEEDURL" >/dev/null; then
     exit 2
 fi
 
+# construct the URL of the falter_release-file. It defines several values, that we need in the building process.
 COMMONFILEURL=$FEEDURL$(curl -s "${FEEDURL}"/Packages | sed -n '/falter-common$/,/^$/p' | awk '{if(/Filename: /) print $2}')
 TMP=$(curl -s "$COMMONFILEURL" | tar xzOf - ./data.tar.gz | tar xzOf - ./etc/freifunk_release)
 eval "$TMP"
@@ -330,7 +331,7 @@ function start_build {
 #    MAIN    #
 ##############
 
-export PARSER_OWT=$(derive_underlying_openwrt_version "$FREIFUNK_OPENWRT_BASE")
+export OPENWRT_BASE_VERSION=$(derive_underlying_openwrt_version "$FREIFUNK_OPENWRT_BASE")
 
 if [ "$PARSER_PACKAGESET" == "all" ]; then
     # split off "-snapshot" for stable-release-snapshots, so we can use the designated stable-packagelist
@@ -365,13 +366,6 @@ sleep 3 # avoid strange issues with database...
 cd build || exit 2
 printf "\tdone.\n"
 
-# read command-line parameters
-# ToDo: unifi the variable names later on...
-# CONF_RELEASE="$PARSER_OWT"
-CONF_TARGET="$PARSER_TARGET"
-CONF_SUBTARGET="$PARSER_SUBTARGET"
-CONF_DEVICE="$PARSER_PROFILE"
-
 # get OpenWrt ToH
 build_router_db
 
@@ -382,7 +376,7 @@ if [ "$FREIFUNK_OPENWRT_BASE" == "master" ]; then
     FREIFUNK_OPENWRT_BASE="snapshots"
 fi
 
-if [ -z "$CONF_TARGET" ] && [ -z "$IMAGE_BUILDER_PATH" ]; then
+if [ -z "$PARSER_TARGET" ] && [ -z "$IMAGE_BUILDER_PATH" ]; then
     # build one release for all targets
     RELEASE_LINK="$RELEASE_LINK_BASE""$FREIFUNK_OPENWRT_BASE""/targets/"
     for target in $(fetch_subdirs "$RELEASE_LINK"); do
@@ -396,35 +390,35 @@ else
     # there was given a release and a target
     RELEASE_LINK="$RELEASE_LINK_BASE""$FREIFUNK_OPENWRT_BASE""/targets/"
     # if there was defined a subtarget and option device, only build that.
-    if [ -n "$CONF_SUBTARGET" ] || [ -n "$IMAGE_BUILDER_PATH" ]; then
+    if [ -n "$PARSER_SUBTARGET" ] || [ -n "$IMAGE_BUILDER_PATH" ]; then
         # build directly that subtarget. if requested, for all image types.
-        TARGET_LIST="$RELEASE_LINK$CONF_TARGET/$CONF_SUBTARGET/"
+        TARGET_LIST="$RELEASE_LINK$PARSER_TARGET/$PARSER_SUBTARGET/"
         IMAGEBUILDER=$(fetch_subdirs "$TARGET_LIST" | grep imagebuilder)
         if [ "$PSET_PATHS" ]; then
             for PKG_SET in $PSET_PATHS; do
                 echo "-> building three packagelists..."
                 read_packageset "../$PKG_SET"
-                start_build "$TARGET_LIST$IMAGEBUILDER" "$PKG_SET" "$CONF_DEVICE"
+                start_build "$TARGET_LIST$IMAGEBUILDER" "$PKG_SET" "$PARSER_PROFILE"
             done
         else
             echo "-> building one packagelist only..."
             # "targets" is on purpose there. Otherwise that positonal argument would be empty.
-            start_build "$TARGET_LIST$IMAGEBUILDER" targets "$CONF_DEVICE"
+            start_build "$TARGET_LIST$IMAGEBUILDER" targets "$PARSER_PROFILE"
         fi
         exit
     fi
     # otherwise, fetch all subtargets and build them one after another.
-    for subtarget in $(fetch_subdirs "$RELEASE_LINK$CONF_TARGET/"); do
-        imagebuilder=$(fetch_subdirs "$RELEASE_LINK$CONF_TARGET/$subtarget" | grep imagebuilder)
+    for subtarget in $(fetch_subdirs "$RELEASE_LINK$PARSER_TARGET/"); do
+        imagebuilder=$(fetch_subdirs "$RELEASE_LINK$PARSER_TARGET/$subtarget" | grep imagebuilder)
         if [ "$PSET_PATHS" ]; then
             for PKG_SET in $PSET_PATHS; do
                 echo "-> building three packagelists..."
                 read_packageset "../$PKG_SET"
-                start_build "$RELEASE_LINK$CONF_TARGET/$subtarget$imagebuilder" "$PKG_SET"
+                start_build "$RELEASE_LINK$PARSER_TARGET/$subtarget$imagebuilder" "$PKG_SET"
             done
         else
             echo "-> building one packagelist only..."
-            start_build "$RELEASE_LINK$CONF_TARGET/$subtarget$imagebuilder"
+            start_build "$RELEASE_LINK$PARSER_TARGET/$subtarget$imagebuilder"
         fi
     done
     exit


### PR DESCRIPTION
build_falter will now check for more dependencies. In addition, we
activated errexit in the shell for every bit of the script, except
the imagebuilder. In the imagbuilder there's the possibility that
one single error might break the whole build (for a whole target).

Fixes #116

Signed-off-by: Martin Hübner <martin.hubner@web.de>

@pktpls I've runtime tested this only with single-device builds. Before merging, we should have a test-run with multi-device-builds, where one device fails.