### PR TITLE
Remove luci-i18n-*-en from snapshot packagesets

### DIFF
--- a/packageset/snapshot/backbone.txt
+++ b/packageset/snapshot/backbone.txt
@@ -46,17 +46,12 @@ luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
 
-# GUI transalation stuff
+# GUI translation stuff
 luci-i18n-base-de
-luci-i18n-base-en
 luci-i18n-olsr-de
-luci-i18n-olsr-en
 luci-i18n-opkg-de
-luci-i18n-opkg-en
 luci-i18n-statistics-de
-luci-i18n-statistics-en
 luci-i18n-falter-de
-luci-i18n-falter-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -56,21 +56,13 @@ luci-theme-bootstrap
 
 # GUI translation stuff
 luci-i18n-base-de
-luci-i18n-base-en
 luci-i18n-firewall-de
-luci-i18n-firewall-en
 luci-i18n-olsr-de
-luci-i18n-olsr-en
 luci-i18n-opkg-de
-luci-i18n-opkg-en
 luci-i18n-statistics-de
-luci-i18n-statistics-en
 luci-i18n-falter-de
-luci-i18n-falter-en
 luci-i18n-ffwizard-falter-de
-luci-i18n-ffwizard-falter-en
 luci-i18n-falter-policyrouting-de
-luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd

--- a/packageset/snapshot/notunnel.txt
+++ b/packageset/snapshot/notunnel.txt
@@ -61,6 +61,7 @@ luci-i18n-olsr-de
 luci-i18n-opkg-de
 luci-i18n-statistics-de
 luci-i18n-falter-de
+luci-i18n-ffwizard-falter-en
 luci-i18n-ffwizard-falter-de
 luci-i18n-falter-policyrouting-de
 

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -60,6 +60,7 @@ luci-i18n-olsr-de
 luci-i18n-opkg-de
 luci-i18n-statistics-de
 luci-i18n-falter-de
+luci-i18n-ffwizard-falter-en
 luci-i18n-ffwizard-falter-de
 luci-i18n-falter-policyrouting-de
 

--- a/packageset/snapshot/tunneldigger.txt
+++ b/packageset/snapshot/tunneldigger.txt
@@ -53,23 +53,15 @@ luci-app-falter-owm-gui
 luci-proto-ppp
 luci-theme-bootstrap
 
-# GUI transaltion stuff
+# GUI translation stuff
 luci-i18n-base-de
-luci-i18n-base-en
 luci-i18n-firewall-de
-luci-i18n-firewall-en
 luci-i18n-olsr-de
-luci-i18n-olsr-en
 luci-i18n-opkg-de
-luci-i18n-opkg-en
 luci-i18n-statistics-de
-luci-i18n-statistics-en
 luci-i18n-falter-de
-luci-i18n-falter-en
 luci-i18n-ffwizard-falter-de
-luci-i18n-ffwizard-falter-en
 luci-i18n-falter-policyrouting-de
-luci-i18n-falter-policyrouting-en
 
 # OLSR
 olsrd


### PR DESCRIPTION
LuCI removed all english translation packages with commit https://github.com/openwrt/luci/commit/94a1821c3b6ec01817e53a8a01a4cf0b7692ac42 Building the snapshot based FW failed because of this missing packages.