### PR TITLE
lib: deactivate luci footer template

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -202,11 +202,13 @@ function generate_embedded_files {
         echo "02-favicon.sh failed..."
         exit 1
     }
-    ../../scripts/03-luci-footer.sh "$FREIFUNK_RELEASE" "$TARGET" "$SUBTARGET" "$FALTERBRANCH" "$FREIFUNK_REVISION" ||
-        {
-            echo "03-luci-footer.sh failed..."
-            exit 1
-        }
+    # TODO: convert the footer template to uc/uCode.
+    #
+    # ../../scripts/03-luci-footer.sh "$FREIFUNK_RELEASE" "$TARGET" "$SUBTARGET" "$FALTERBRANCH" "$FREIFUNK_REVISION" ||
+    #     {
+    #         echo "03-luci-footer.sh failed..."
+    #         exit 1
+    #     }
     export REPO # export repo line to inject into images. contains whitespace...
     ../../scripts/04-include-falter-feed.sh "$url" "$fingerprint" || {
         echo "04-include-falter-feed.sh failed..."


### PR DESCRIPTION
Das Footer-Template, das wir da bearbeiten, wurde inzwischen zu uc/uCode umgewandelt, das müssten wir entsprechend ebenfalls machen. Bis dahin erstmal auskommentieren, es ist nur ein kosmetisches Ding und verhindert aktuell die 1.3.0-snapshot builds.