### PR TITLE
workflows: update checkout action to v3

### DIFF
--- a/.config/yaml-lint.yml
+++ b/.config/yaml-lint.yml
@@ -1,0 +1,15 @@
+---
+# This extends the default yaml-lint conf by adjusting some options.
+
+extends: default
+
+rules:
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  document-start:
+    level: error
+  line-length:
+    max: 2048
+    level: warning

--- a/.github/workflows/shellcheck-lint.yml
+++ b/.github/workflows/shellcheck-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lint ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lint Yaml Files
         uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,16 @@
+---
+name: Yaml Lint
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+jobs:
+  build:
+    name: Yaml Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint Yaml Files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .config/yaml-lint.yml


### PR DESCRIPTION
switch to v3 because v2 is deprecated

Signed-off-by: Tobias Schwarz [info@tobias-schwarz.com](mailto:info@tobias-schwarz.com)