### PR TITLE
workflows: update checkout action to v3

### DIFF
--- a/.github/workflows/shellcheck-lint.yml
+++ b/.github/workflows/shellcheck-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lint ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Lint Yaml Files
         uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
switch to v3 because v2 is deprecated

Signed-off-by: Tobias Schwarz <info@tobias-schwarz.com>