### PR TITLE
buildconf: update broken targets

### DIFF
--- a/.buildconf/broken-1.2.3-snapshot.txt
+++ b/.buildconf/broken-1.2.3-snapshot.txt
@@ -1,10 +1,10 @@
 # Doesn't provide any device profiles that could be built
+arc770/generic
 archs38/generic
 armvirt/32
 armvirt/64
 malta/be
 octeontx/generic
-realtek/rtl931x
 
 # Broken: cferam.000 - No such file or directory
 bcm4908/generic

--- a/.buildconf/broken-snapshot.txt
+++ b/.buildconf/broken-snapshot.txt
@@ -1,5 +1,4 @@
 # Doesn't provide any device profiles that could be built
-archs38/generic
 armvirt/32
 armvirt/64
 malta/be


### PR DESCRIPTION
- archs38 was removed on snapshot
- the list for 1.2.3-snapshot was copied from snapshot, but needed a few tweeks