### PR TITLE
buildconf: update broken targets

### DIFF
--- a/.buildconf/broken-1.3.0-snapshot.txt
+++ b/.buildconf/broken-1.3.0-snapshot.txt
@@ -2,6 +2,7 @@
 archs38/generic
 armvirt/32
 armvirt/64
+imx/cortexa7
 malta/be
 octeontx/generic
 realtek/rtl931x


### PR DESCRIPTION
imx/cortexa7 doesn't have any device profiles in 22.03, only in snapshot