### PR TITLE
build: explicitly define our branches

### DIFF
--- a/build_falter
+++ b/build_falter
@@ -17,7 +17,7 @@ export BUILTER_DIR=$(dirname "$REALPATH_SCRIPT")
 RELEASE_LINK_BASE="https://downloads.openwrt.org/releases/"
 
 # General variables
-FALTER_REPO_BASE="src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed/"
+FALTER_REPO_BASE="src/gz openwrt_falter https://firmware.berlin.freifunk.net/feed"
 FREIFUNK_RELEASE=""
 export OPENWRT_TOH="https://openwrt.org/_media/toh_dump_tab_separated.gz"
 
@@ -171,19 +171,18 @@ done
 
 print_banner
 
-# repository derives directly from the falter-version. Download freifunk_release
-# file and determine openwrt-version by its variables
-BASE_URL=$(echo "$FALTER_REPO_BASE" | cut -d' ' -f 3)
-FEEDURL="$BASE_URL$PARSER_FALTER_VERSION/packages/mips_24kc/falter/"
-if ! curl --silent --fail "$FEEDURL" >/dev/null; then
-    echo "Error: failed retrieving feed URL. Wrong version '$PARSER_FALTER_VERSION'?"
-    exit 2
+export FREIFUNK_RELEASE="$PARSER_FALTER_VERSION"
+export FREIFUNK_REVISION=""
+export FREIFUNK_OPENWRT_BASE="snapshot"
+FEED_VERSION="snapshot"
+if [[ $FREIFUNK_RELEASE =~ ^1\.3\.0 ]]; then
+    FREIFUNK_OPENWRT_BASE="22.03-SNAPSHOT"
+    FEED_VERSION="1.3.0-snapshot"
 fi
-
-# construct the URL of the falter_release-file. It defines several values, that we need in the building process.
-COMMONFILEURL=$FEEDURL$(curl -s "${FEEDURL}"/Packages | sed -n '/falter-common$/,/^$/p' | awk '{if(/Filename: /) print $2}')
-TMP=$(curl -s "$COMMONFILEURL" | tar xzOf - ./data.tar.gz | tar xzOf - ./etc/freifunk_release)
-eval "$TMP"
+if [[ $FREIFUNK_RELEASE =~ ^1\.2\.3 ]]; then
+    FREIFUNK_OPENWRT_BASE="21.02-SNAPSHOT"
+    FEED_VERSION="1.2.3-snapshot"
+fi
 
 function start_build {
     # use local imagebuilder if it was given
@@ -262,7 +261,7 @@ function start_build {
     INSTR_SET=$(grep "openwrt_base" repositories.conf | awk -F'/' "{print \$$ispos}")
     echo "selected instruction set: $INSTR_SET"
 
-    REPO="$FALTER_REPO_BASE/$PARSER_FALTER_VERSION/packages/$INSTR_SET/falter"
+    REPO="$FALTER_REPO_BASE/$FEED_VERSION/packages/$INSTR_SET/falter"
     echo "injecting repo line: $REPO"
     echo "$REPO" >>repositories.conf
 
@@ -323,12 +322,7 @@ function start_build {
 export OPENWRT_BASE_VERSION=$(derive_underlying_openwrt_version "$FREIFUNK_OPENWRT_BASE")
 
 if [ "$PARSER_PACKAGESET" == "all" ]; then
-    # split off "-snapshot" for stable-release-snapshots, so we can use the designated stable-packagelist
-    if echo "$FREIFUNK_RELEASE" | grep "snapshot\|rc"; then
-        ff_release=$(echo "$FREIFUNK_RELEASE" | cut -d'-' -f1)
-    else
-        ff_release="$FREIFUNK_RELEASE"
-    fi
+    ff_release=$(echo "$FREIFUNK_RELEASE" | cut -d'-' -f1)
 
     # build all imageflavours. For this, get paths of packagesets
     # fetch paths of packagelists (depends on openwrt-version). If not unique, chose most recent version of possibilities.
@@ -360,7 +354,7 @@ build_router_db
 
 # if openwrt_base is "master": change to "snapshots". That is the correct
 # directory for downloading openwrt-master
-if [ "$FREIFUNK_OPENWRT_BASE" == "master" ]; then
+if [ "$FREIFUNK_OPENWRT_BASE" == "master" ] || [ "$FREIFUNK_OPENWRT_BASE" == "snapshot" ] ; then
     RELEASE_LINK_BASE="https://downloads.openwrt.org/"
     FREIFUNK_OPENWRT_BASE="snapshots"
 fi

--- a/build_falter
+++ b/build_falter
@@ -171,18 +171,29 @@ done
 
 print_banner
 
+if [[ $PARSER_FALTER_VERSION =~ ^1\.3\.0 ]]; then
+    FEED_VERSION="1.3.0-snapshot"
+    if [[ $PARSER_FALTER_VERSION =~ snapshot ]]; then
+        FREIFUNK_OPENWRT_BASE="22.03-SNAPSHOT"
+    else
+        FREIFUNK_OPENWRT_BASE="22.03.4"
+    fi
+elif [[ $PARSER_FALTER_VERSION =~ ^1\.2\.3 ]]; then
+    FEED_VERSION="1.2.3-snapshot"
+    if [[ $PARSER_FALTER_VERSION =~ snapshot ]]; then
+        FREIFUNK_OPENWRT_BASE="21.02-SNAPSHOT"
+    else
+        FREIFUNK_OPENWRT_BASE="21.02.5"
+    fi
+else
+    FREIFUNK_OPENWRT_BASE="snapshot"
+    FEED_VERSION="snapshot"
+fi
+
+export FEED_VERSION="$FEED_VERSION"
+export FREIFUNK_OPENWRT_BASE="$FREIFUNK_OPENWRT_BASE"
 export FREIFUNK_RELEASE="$PARSER_FALTER_VERSION"
 export FREIFUNK_REVISION=""
-export FREIFUNK_OPENWRT_BASE="snapshot"
-FEED_VERSION="snapshot"
-if [[ $FREIFUNK_RELEASE =~ ^1\.3\.0 ]]; then
-    FREIFUNK_OPENWRT_BASE="22.03-SNAPSHOT"
-    FEED_VERSION="1.3.0-snapshot"
-fi
-if [[ $FREIFUNK_RELEASE =~ ^1\.2\.3 ]]; then
-    FREIFUNK_OPENWRT_BASE="21.02-SNAPSHOT"
-    FEED_VERSION="1.2.3-snapshot"
-fi
 
 function start_build {
     # use local imagebuilder if it was given

--- a/build_falter
+++ b/build_falter
@@ -60,10 +60,7 @@ Options:
     Maps directly to the directories at https://firmware.berlin.freifunk.net/feed/
 
   -t [TARGET]
-    target like 'ath79'
-
-  -s [SUBTARGET]
-    something like 'generic'. This is optional.
+    target like 'ath79/generic' or 'x86/64'.
 
   -r [ROUTER-PROFILE]
     give a router-profile like 'glinet_gl-ar150'. This is optional.
@@ -115,26 +112,16 @@ while getopts dp:v:t:s:r:i:lh option; do
         ;;
     t)
         if [[ "$OPTARG" != -* ]]; then
-            IFS='/' read -r optt optst <<< "$OPTARG"
-            echo "Target is: $optt"
-            PARSER_TARGET="$optt"
-            if [ -n "$optst" ]; then
-                echo "Sub-Target is: $optst"
-                PARSER_SUBTARGET="$optst"
-            fi
+            echo "Target is: $OPTARG"
+            PARSER_TARGET="$OPTARG"
         else
-            echo "Please give a target with '-t'."
+            echo "Please specify a target with option '-t'."
             exit 1
         fi
         ;;
     s)
-        if [[ "$OPTARG" != -* ]]; then
-            echo "Sub-Target is: $OPTARG"
-            PARSER_SUBTARGET="$OPTARG"
-        else
-            echo "Please give a subtarget with option '-s'."
-            exit 1
-        fi
+        echo "The '-s' option has been removed, use e.g. '-t ath79/generic'."
+        exit 1
         ;;
     r)
         if [[ "$OPTARG" != -* ]]; then
@@ -166,12 +153,11 @@ done
 printf "\n"
 
 # check if we got all options we would need.
-if [ -z "$PARSER_FALTER_VERSION" ] || [ -z "$PARSER_TARGET" ] || [ -z "$PARSER_SUBTARGET" ] || [ -z "$PARSER_PACKAGESET" ]; then
+if [ -z "$PARSER_FALTER_VERSION" ] || [ -z "$PARSER_TARGET" ] || [ -z "$PARSER_PACKAGESET" ]; then
     printf "Please specify at least theses options:\n\
     -v\t[falter-version],\n\
     -p\t[packagelist],\n\
-    -t\t[target],\n\
-    -s\t[subtarget]\n\n"
+    -t\t[target]\n\n"
     exit 1
 fi
 
@@ -388,41 +374,21 @@ if [ -z "$PARSER_TARGET" ] && [ -z "$IMAGE_BUILDER_PATH" ]; then
             start_build "$RELEASE_LINK$target$subtarget$imagebuilder"
         done
     done
-    exit
 else
     # there was given a release and a target
     RELEASE_LINK="$RELEASE_LINK_BASE""$FREIFUNK_OPENWRT_BASE""/targets/"
-    # if there was defined a subtarget and option device, only build that.
-    if [ -n "$PARSER_SUBTARGET" ] || [ -n "$IMAGE_BUILDER_PATH" ]; then
-        # build directly that subtarget. if requested, for all image types.
-        TARGET_LIST="$RELEASE_LINK$PARSER_TARGET/$PARSER_SUBTARGET/"
-        IMAGEBUILDER=$(fetch_subdirs "$TARGET_LIST" | grep imagebuilder)
-        if [ "$PSET_PATHS" ]; then
-            for PKG_SET in $PSET_PATHS; do
-                echo "-> building three packagelists..."
-                read_packageset "../$PKG_SET"
-                start_build "$TARGET_LIST$IMAGEBUILDER" "$PKG_SET" "$PARSER_PROFILE"
-            done
-        else
-            echo "-> building one packagelist only..."
-            # "targets" is on purpose there. Otherwise that positonal argument would be empty.
-            start_build "$TARGET_LIST$IMAGEBUILDER" targets "$PARSER_PROFILE"
-        fi
-        exit
+    # build directly that target. if requested, for all image types.
+    TARGET_LIST="$RELEASE_LINK$PARSER_TARGET/"
+    IMAGEBUILDER=$(fetch_subdirs "$TARGET_LIST" | grep imagebuilder)
+    if [ "$PSET_PATHS" ]; then
+        for PKG_SET in $PSET_PATHS; do
+            echo "-> building three packagelists..."
+            read_packageset "../$PKG_SET"
+            start_build "$TARGET_LIST$IMAGEBUILDER" "$PKG_SET" "$PARSER_PROFILE"
+        done
+    else
+        echo "-> building one packagelist only..."
+        # "targets" is on purpose there. Otherwise that positonal argument would be empty.
+        start_build "$TARGET_LIST$IMAGEBUILDER" targets "$PARSER_PROFILE"
     fi
-    # otherwise, fetch all subtargets and build them one after another.
-    for subtarget in $(fetch_subdirs "$RELEASE_LINK$PARSER_TARGET/"); do
-        imagebuilder=$(fetch_subdirs "$RELEASE_LINK$PARSER_TARGET/$subtarget" | grep imagebuilder)
-        if [ "$PSET_PATHS" ]; then
-            for PKG_SET in $PSET_PATHS; do
-                echo "-> building three packagelists..."
-                read_packageset "../$PKG_SET"
-                start_build "$RELEASE_LINK$PARSER_TARGET/$subtarget$imagebuilder" "$PKG_SET"
-            done
-        else
-            echo "-> building one packagelist only..."
-            start_build "$RELEASE_LINK$PARSER_TARGET/$subtarget$imagebuilder"
-        fi
-    done
-    exit
 fi

--- a/lib.bash
+++ b/lib.bash
@@ -216,7 +216,7 @@ function generate_embedded_files {
         echo "02-favicon.sh failed..."
         exit 1
     }
-    ../../scripts/03-luci-footer.sh "$FREIFUNK_RELEASE" "$TARGET" "$SUBTARGET" "$FALTERBRANCH" "$FREIFUNK_REVISION" ||
+    ../../scripts/03-luci-footer.sh "$FREIFUNK_RELEASE" "$TARGET/$SUBTARGET" "$FALTERBRANCH" "$FREIFUNK_REVISION" ||
         {
             echo "03-luci-footer.sh failed..."
             exit 1

--- a/scripts/03-luci-footer.sh
+++ b/scripts/03-luci-footer.sh
@@ -2,9 +2,8 @@
 
 VERSION="$1"
 TARGET="$2"
-SUBTARGET="$3"
-OPENWRT_BASE="$4"
-REVISION="$5"
+OPENWRT_BASE="$3"
+REVISION="$4"
 # get current path of script. Thus we can call the script from everywhere.
 SCRIPTPATH=$(dirname "$(readlink -f "$0")")
 
@@ -15,7 +14,7 @@ if [ "$OPENWRT_BASE" = "openwrt-19.07" ] || [ "$OPENWRT_BASE" = "openwrt-21.02" 
     mkdir -p "$FOOTERDIR" || exit 42
 
     wget -q -P "$FOOTERDIR" "$SRCFOOTER" || exit 42
-    sed -i "/Powered by.*/a \ \ \ \ <br><a href=\"https://berlin.freifunk.net\">Freifunk Berlin</a> ($NICKNAME v$VERSION - $REVISION) $TARGET - $SUBTARGET" "$FOOTERDIR/footer.htm" || exit 42
+    sed -i "/Powered by.*/a \ \ \ \ <br><a href=\"https://berlin.freifunk.net\">Freifunk Berlin</a> (Falter v$VERSION - $REVISION) $TARGET" "$FOOTERDIR/footer.htm" || exit 42
 else
     SRCFOOTER="https://raw.githubusercontent.com/openwrt/luci/${OPENWRT_BASE}/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/footer.ut"
 
@@ -24,5 +23,5 @@ else
     wget -q -P "$FOOTERDIR" "$SRCFOOTER" || exit 42
 
     sed -i 's|{{ entityencode(version.disturl ?? .*, true) }}|https://berlin.freifunk.net|g' "$FOOTERDIR/footer.ut" || exit 42
-    sed -i "s|{{ version.distname }} {{ version.distversion }} ({{ version.distrevision }})|($NICKNAME v$VERSION - $REVISION) $TARGET - $SUBTARGET|g" "$FOOTERDIR/footer.ut" || exit 42
+    sed -i "s|{{ version.distname }} {{ version.distversion }} ({{ version.distrevision }})|(Falter v$VERSION - $REVISION) $TARGET|g" "$FOOTERDIR/footer.ut" || exit 42
 fi

--- a/scripts/05-inject-freifunk-release.sh
+++ b/scripts/05-inject-freifunk-release.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+# get current path of script. Thus we can call the script from everywhere.
+SCRIPTPATH=$(dirname "$(readlink -f "$0")")
+
+dir="$SCRIPTPATH/../embedded-files/etc"
+mkdir -p "$dir" || exit 42
+
+{
+  echo "FREIFUNK_DISTRIB_ID='Freifunk Falter'"
+  echo "FREIFUNK_RELEASE='$1'"
+  echo "FREIFUNK_OPENWRT_BASE='$2'"
+  echo "FREIFUNK_REVISION=''"
+} > "$dir/freifunk_release"


### PR DESCRIPTION
Two little fixes and a big one:

The freifunk_release file in falter-common is not the source of truth
for release branching and versioning anymore. The falter package feeds
are now rolling snapshot feeds just like OpenWrt's.

In this commit we stop reading the freifunk_release file and instead
explicitly define our release branching and versioning. It needs
to be updated whenever a new release branch is created, such as when
openwrt-22.03 was created and openwrt-19.07 removed.

In this commit we also start injecting a new freifunk_release file
into the image.

These two changes change how our releases are defined and started:

Previously we'd commit an updated freifunk_release file to the
falter-packages repo, then build the package feed, the build the
images.

Now all builds are the same and snapshot by default. We call
`build_falter` with `-v 1.2.3` for a snapshot release and with
`-v 1.2.3-snapshot` for a snapshot iamge. It takes care of all
branch-related and version-related information and injects it
into the image.

The differences b/w a snapshot image and release image are simple:
- Image filename
- FREIFUNK_RELEASE variable in /etc/freifunk_release
- Subdirectory on firmware.berlin.freifunk.net
  - stable/ vs. unstable/ (Buildbot will take care of this)
- Built using different schedulers (= buttons) in Buildbot

Things snapshot and release have in common:
- Built using the same Buildbot builder
- Built using OpenWrt snapshot imagebuilder (matching the branch)
- Using falter snapshot packages feed (matching the branch)

Open questions:
- FREIFUNK_REVISION in /etc/freifunk_release used to contain the
  falter package feed git revision, but we don't have knowledge of
  that during a targets build. OPENWRT_REVISION on the other hand
  contains the revision of openwrt.git, so maybe using the falter-builter.git
  revision would be better, anyway.
- It would be easy to build releases using Openwrt release imagebuilders.
  That'd cover device support, kmods, and the base package beed.
  (All other feeds are now rolling snapshot-only.)