### PR TITLE
treewide: rename master branch to main

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -55,6 +55,5 @@ jobs:
         uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          # Change to 'master' if your main branch differs
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build_falter
+++ b/build_falter
@@ -367,9 +367,9 @@ printf "\tdone.\n"
 # get OpenWrt ToH
 build_router_db
 
-# if openwrt_base is "master": change to "snapshots". That is the correct
-# directory for downloading openwrt-master
-if [ "$FREIFUNK_OPENWRT_BASE" == "master" ] || [ "$FREIFUNK_OPENWRT_BASE" == "snapshot" ] ; then
+# if openwrt_base is "main": change to "snapshots". That is the correct
+# directory for downloading openwrt main
+if [ "$FREIFUNK_OPENWRT_BASE" == "main" ] || [ "$FREIFUNK_OPENWRT_BASE" == "snapshot" ] ; then
     RELEASE_LINK_BASE="https://downloads.openwrt.org/"
     FREIFUNK_OPENWRT_BASE="snapshots"
 fi

--- a/lib.bash
+++ b/lib.bash
@@ -183,8 +183,8 @@ function generate_embedded_files {
 
     # Get the FREIFUNK_RELEASE variable from the falter feed
     # located in the falter-common package.
-    [ "snapshot" == "$FALTERBRANCH" ] && FALTERBRANCH="master"
-    [ "$FALTERBRANCH" != "master" ] && FALTERBRANCH="openwrt-$OPENWRT_BASE_VERSION"
+    [ "snapshot" == "$FALTERBRANCH" ] && FALTERBRANCH="main"
+    [ "$FALTERBRANCH" != "main" ] && FALTERBRANCH="openwrt-$OPENWRT_BASE_VERSION"
 
     # clear out any old embedded_files
     rm -rf ../../embedded-files/*


### PR DESCRIPTION
See freifunk-berlin/meta#64

Do the following in your local clones of the repository:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```