### PR TITLE
build: small image selection fixes

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -32,7 +32,7 @@ function usage() {
         echo -n "  all"
         (
             cd "$rootdir/tmp/$orelease/$target"
-            list=$(make info |& sed -n 's/\(^[a-zA-Z0-9_-]*\)\:$/\1/p' | sort | grep -v Default || true)
+            list=$(make info |& sed -n 's/\(^[a-zA-Z0-9_-]*\)\:$/\1/p' | sort || true)
             for p in $list; do
                 echo -n "  $p"
             done
@@ -233,7 +233,7 @@ EOF
     cp "$rootdir/store/favicon.png" "$d/"
 
     # go over all devices and build them
-    profilelist=$(make info | sed -n 's/\(^[a-zA-Z0-9_-]*\)\:$/\1/p' | sort | grep -v Default || true)
+    profilelist=$(make info | sed -n 's/\(^[a-zA-Z0-9_-]*\)\:$/\1/p' | sort || true)
     echo -n "building profiles:"
     echo "$profilelist" | xargs echo -n "  "
     echo
@@ -295,7 +295,7 @@ EOF
             |& tee "bin/targets/$target/faillogs/$p.log" >&2
 
         # if build resulted in image files, we can delete the log
-        cnt="$(find "bin/targets/$target/" -name "*$p*.bin" -or -name "*$p*.img" -or -name "*$p*.gz" | wc -l)"
+        cnt="$(find "bin/targets/$target/" -iname "*$p*.bin" -or -iname "*$p*.img" -or -iname "*$p*.gz" -or -iname "*$p*.ubi" -or -iname "*Image*" | wc -l)"
         if [ "$cnt" -gt 0 ]; then
             rm -v "bin/targets/$target/faillogs/$p.log"
         fi
@@ -303,7 +303,7 @@ EOF
 ) \
     |& tee "$destdir/build.log" >&2
 
-find "$ibdir/bin/targets/$target" \( -name '*.bin' -or -name '*.img' -or -name '*.gz' -or -name 'profiles.json' \) -exec mv -v '{}' "$destdir/" \;
+find "$ibdir/bin/targets/$target" \( -name '*.bin' -or -name '*.img' -or -name '*.gz' -or -name '*.ubi' -or -name '*Image*' -or -name 'profiles.json' \) -exec mv -v '{}' "$destdir/" \;
 mv "$ibdir/bin/targets/$target/faillogs" "$destdir/"
 
 echo "Done."

--- a/test/vm.sh
+++ b/test/vm.sh
@@ -179,6 +179,6 @@ EOF
 # to run tests in container: cd /vmdir/builter-test ; ./wizard-tester.py node_example.json
 cp -avx "test" "$vmdir/builter-test"
 
-podman run -it --rm --name="$host" -v "$(realpath $vmdir):/vmdir:Z" --user=root --userns=keep-id --device=/dev/kvm --device=/dev/net/tun --security-opt="label=disable" --cap-add=NET_ADMIN --cap-add=NET_RAW --network=slirp4netns:mtu=1280 -p 8022:8022 -p 8053:8053/udp -p 8080:8080 -p 8443:8443 localhost/falter-testing /vmdir/entrypoint.sh
+podman run -it --rm --name="$host" -v "$(realpath $vmdir):/vmdir:Z" --user=root --userns=keep-id --device=/dev/kvm --device=/dev/net/tun --security-opt="label=disable" --cap-add=NET_ADMIN --cap-add=NET_RAW --network=slirp4netns -p 8022:8022 -p 8053:8053/udp -p 8080:8080 -p 8443:8443 localhost/falter-testing /vmdir/entrypoint.sh
 
 echo "Done."

--- a/test/vm.sh
+++ b/test/vm.sh
@@ -127,7 +127,7 @@ interface "$ifname" {
 EOF2
 
 mkdir -p /run/dhcp
-dhclient -d $ifname &
+udhcpc -b -i $ifname
 
 netmask() {
   local mask=$((0xffffffff << (32 - $1))); shift
@@ -168,7 +168,7 @@ FROM alpine:edge
 
 RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk upgrade musl
-RUN apk add bash openssh-client git vim mtr curl wget tcpdump iproute2 bridge-utils dhclient firecracker socat jq
+RUN apk add bash openssh-client git vim mtr curl wget tcpdump iproute2 bridge-utils firecracker socat jq
 
 RUN apk add python3 py3-pip ca-certificates py3-openssl openssl-dev
 RUN pip3 install --break-system-packages selenium pyvirtualdisplay


### PR DESCRIPTION
We don't need to skip "Default" images, they do build correctly.
But the profile part of their filenames is lowercase, so we need
find's -iname option, instead of -name which is case-sensitive.

Additionally, include Image (kernel images) and *.ubi files in output.

Also, two small VM script fixes from bbb-configs:
- use udhcpc instead of dhclient, which has been deprecated and removed from Alpine
- fix the MTU between host and container
