### PR TITLE
build: new autoupdate.json generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ lint: shellcheck # TODO: gitleaks flake8 pylint
 .PHONY: lint
 
 shfmt:
-	shfmt -ln=bash -l build/build.sh test/vm.sh | xargs shfmt -w -l -ln=bash -i 4 -ci -bn
+	shfmt -ln=bash -l build/*.sh test/*.sh | grep -v extract-vmlinux | xargs shfmt -w -l -ln=bash -i 4 -ci -bn
 .PHONY: shfmt
 
 shellcheck:
-	shellcheck -S warning build/build.sh test/vm.sh
+	shellcheck -S warning build/*.sh test/*.sh
 .PHONY: shellcheck

--- a/build/generate-autoupdate.sh
+++ b/build/generate-autoupdate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Usage: generate-autoupdate.sh <version> <out-dir>
+
+function usage() {
+    exit 1
+}
+
+set -e
+set -o pipefail
+# set -x
+
+[ -n "$1" ] && fversion="$1" || usage >&2
+[ -n "$2" ] && outdir="$2" || outdir="./out"
+
+(
+    echo '{"falter-version": "'"$fversion"'"}'
+
+    # .devices
+    cat "$outdir/$fversion"/*/*/*/profiles.json | jq -s '.[] as $t | $t.profiles | keys[] as $p | $t.profiles[$p] | .supported_devices | unique | .[] | select(contains(",")) | {(.): {target: $t.target, profile: $p}}' | jq -S -s 'add | {devices: (.)}'
+
+    # .profiles[].tunneldigger
+    for f in "$outdir/$fversion"/tunneldigger/*/*/profiles.json; do
+        target="$(cat "$f" | jq -r .target)"
+        shasum="$(sha256sum "$f" | cut -d' ' -f1)"
+        url="/unstable/$fversion/tunneldigger/$target/profiles.json"
+        echo '{"profiles": {"'"$target"'": {"tunneldigger": {"url": "'"$url"'", "sha256sum": "'"$shasum"'"}}}}'
+    done
+
+    # .profiles[].notunnel
+    for f in "$outdir/$fversion"/notunnel/*/*/profiles.json; do
+        target="$(cat "$f" | jq -r .target)"
+        shasum="$(sha256sum "$f" | cut -d' ' -f1)"
+        url="/unstable/$fversion/notunnel/$target/profiles.json"
+        echo '{"profiles": {"'"$target"'": {"notunnel": {"url": "'"$url"'", "sha256sum": "'"$shasum"'"}}}}'
+    done
+
+    # .target[][].tunneldigger
+    cat "$outdir/$fversion"/tunneldigger/*/*/profiles.json | jq -r '.target as $t | .profiles | keys[] as $p | .[$p].images[] | select(.type == "sysupgrade") | {target: {($t): {($p): {notunnel: .sha256}}}}'
+
+    # .target[][].notunnel
+    cat "$outdir/$fversion"/notunnel/*/*/profiles.json | jq -r '.target as $t | .profiles | keys[] as $p | .[$p].images[] | select(.type == "sysupgrade") | {target: {($t): {($p): {tunneldigger: .sha256}}}}'
+
+) | jq -s 'reduce .[] as $o ({}; . * $o)'

--- a/test/extract-vmlinux.sh
+++ b/test/extract-vmlinux.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC1000-SC9999
 # SPDX-License-Identifier: GPL-2.0-only
 # ----------------------------------------------------------------------
 # extract-vmlinux - Extract uncompressed vmlinux from a kernel image


### PR DESCRIPTION
Example output for 1.4.0: https://gist.github.com/pktpls/74c98f1bcc62fb14df6e31edac988844

- .devices and .profiles are new and will support the autoupdater dealing with devices changing their target.
- .falter-version has existed before.
- .target has also existed before, and will be removed in the future.
- .image_url is unused and has been removed.

(Sorry I should have just edited the existing generate_autoupdate_json.py - I only noticed later...)
