### PR TITLE
packageset: add missing 1.4.x packages

### DIFF
--- a/packageset/1.4.0/notunnel.txt
+++ b/packageset/1.4.0/notunnel.txt
@@ -31,6 +31,7 @@ falter-policyrouting
 falter-profiles
 # allow upgrade from one type to another
 falter-berlin-tunneldigger
+falter-berlin-ssid-changer
 
 # Save disk space
 -luci-proto-ppp
@@ -67,6 +68,12 @@ luci-i18n-falter-de
 luci-i18n-ffwizard-falter-de
 luci-i18n-falter-policyrouting-de
 
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
+
 # service registrar
 falter-berlin-service-registrar
 luci-app-falter-service-registrar
@@ -80,7 +87,6 @@ olsrd-mod-dyn-gw
 olsrd-mod-jsoninfo
 olsrd-mod-txtinfo
 olsrd-mod-nameservice
-olsrd-mod-watchdog
 kmod-ipip
 
 # Uplink

--- a/packageset/1.4.0/tunneldigger.txt
+++ b/packageset/1.4.0/tunneldigger.txt
@@ -30,6 +30,8 @@ falter-common
 falter-common-olsr
 falter-policyrouting
 falter-profiles
+falter-berlin-tunneldigger
+falter-berlin-ssid-changer
 
 # Save disk space
 -luci-proto-ppp
@@ -65,6 +67,12 @@ luci-i18n-statistics-de
 luci-i18n-falter-de
 luci-i18n-ffwizard-falter-de
 luci-i18n-falter-policyrouting-de
+
+# autoupdate
+falter-berlin-autoupdate
+falter-berlin-autoupdate-keys
+luci-app-falter-autoupdate
+luci-i18n-falter-autoupdate-de
 
 # service registrar
 falter-berlin-service-registrar

--- a/test/vm.sh
+++ b/test/vm.sh
@@ -179,6 +179,6 @@ EOF
 # to run tests in container: cd /vmdir/builter-test ; ./wizard-tester.py node_example.json
 cp -avx "test" "$vmdir/builter-test"
 
-podman run -it --rm --name="$host" -v "$(realpath $vmdir):/vmdir:Z" --user=root --userns=keep-id --device=/dev/kvm --device=/dev/net/tun --security-opt="label=disable" --cap-add=NET_ADMIN --cap-add=NET_RAW --network=slirp4netns -p 8022:8022 -p 8053:8053/udp -p 8080:8080 -p 8443:8443 localhost/falter-testing /vmdir/entrypoint.sh
+podman run -it --rm --name="$host" -v "$(realpath $vmdir):/vmdir:Z" --user=root --userns=keep-id --device=/dev/kvm --device=/dev/net/tun --security-opt="label=disable" --cap-add=NET_ADMIN --cap-add=NET_RAW --network=slirp4netns:mtu=1280 -p 8022:8022 -p 8053:8053/udp -p 8080:8080 -p 8443:8443 localhost/falter-testing /vmdir/entrypoint.sh
 
 echo "Done."


### PR DESCRIPTION
I made some mistakes while creating the 1.4.x branch. The autoupdater, tunneldigger, and ssid-changer packages somehow went missing.

I'll do a full test build, some smaller devices might fail to build because of the slight increase in disk space usage.

If all goes well, I'll click the 1.4.1 release in the night.