### PR TITLE
vm: make DNS work

### DIFF
--- a/test/vm.sh
+++ b/test/vm.sh
@@ -148,6 +148,10 @@ socat -d -4 TCP-LISTEN:8022,fork,reuseaddr TCP-CONNECT:$gw:22 &
 socat -d -4 UDP-LISTEN:8053,fork,reuseaddr UDP-CONNECT:$gw:53 &
 socat -d -4 TCP-LISTEN:8080,fork,reuseaddr TCP-CONNECT:$gw:80 &
 socat -d -4 TCP-LISTEN:8443,fork,reuseaddr TCP-CONNECT:$gw:443 &
+
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@$gw \
+  "uci -q del dhcp.@dnsmasq[0].server ; uci add_list dhcp.@dnsmasq[0].server='10.0.2.3' ; uci commit ; reload_config"
+
 echo "portfwd.sh: available on 127.0.0.1: 8022 (ssh) 8053 (dns) 8080 (http) 8443 (https)"
 EOF
 chmod +x "$vmdir/portfwd.sh"

--- a/test/vm.sh
+++ b/test/vm.sh
@@ -114,17 +114,7 @@ cat <<'EOF' >"$vmdir/portfwd.sh"
 ifname="$1"
 
 ip addr flush $ifname
-killall dhclient || true
 killall socat || true
-
-# heredoc with variable interpolation
-cat << EOF2 > /etc/dhcp/dhclient.conf
-interface "$ifname" {
-  request subnet-mask, broadcast-address, interface-mtu;
-  initial-interval 1;
-  backoff-cutoff 2;
-}
-EOF2
 
 mkdir -p /run/dhcp
 udhcpc -b -i $ifname


### PR DESCRIPTION
In Podman with slirp4netns, the DNS server for containers is not on the same IP as the gateway. We can't configure slirp4netns to advertise the DNS server in DHCP replies, so we need to tell OpenWrt about it explicitly.