### PR TITLE
feat: use berlin mirror

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -104,7 +104,7 @@ set -x
 
 frevision=$(git rev-parse --short HEAD)
 
-owmirror="https://downloads.openwrt.org"
+owmirror="https://mirror.berlin.freifunk.net/downloads.openwrt.org"
 [ -z "$OPENWRT_MIRROR" ] || owmirror="$OPENWRT_MIRROR"
 fmirror="https://firmware.berlin.freifunk.net"
 [ -z "$FALTER_MIRROR" ] || fmirror="$FALTER_MIRROR"


### PR DESCRIPTION
Falter-images should be built from the freifunk berlin mirror of the openwrt repos.