### PR TITLE
build: provide a container to run builds in

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,0 +1,8 @@
+FROM docker.io/library/debian:testing
+ARG rebuild=2026-09-05
+
+RUN apt update && apt install -y --no-install-recommends --no-install-suggests binutils-gold bison build-essential ca-certificates file flex g++ gawk gettext git-core libbsd-dev libelf-dev libncurses-dev libssl-dev meson mold ninja-build pbzip2 pigz pkg-config python3-dev python3-setuptools rsync sqlite3 subversion time unzip wget xxd zlib1g-dev zstd
+
+VOLUME /work
+WORKDIR /work
+ENTRYPOINT ["build/build.sh"]

--- a/build/container.sh
+++ b/build/container.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+iidfile=./.tmp-falter-image-id.txt
+podman build --iidfile=$iidfile --pull=newer --network=host build/
+img=$(cat $iidfile)
+rm -f $iidfile
+
+echo
+echo "Executing build/build.sh $*"
+echo
+podman run -it --rm --log-driver=none -v "$(pwd):/work:Z" --userns=keep-id \
+  -e OPENWRT_MIRROR -e FALTER_MIRROR -e FALTER_VARIANT -e FALTER_FEED -e FALTER_FEEDKEY \
+  "$img" "$@"


### PR DESCRIPTION
Compile tested: all of them
Run tested: n/a

Description of your changes:

Fixed buildbot depends on this.

This new `build/container.sh` script wraps `build.sh` in a debian container which is very similar to upstream's build containers. The same container is now also used by our buildbot, except with different startup parameters.

- Debian image is refreshed whenever a new one is published
- Full workdir is mounted into the container, the file permissions should be okay hopefully
- Environment variables like OPENWRT_MIRROR and FALTER_VARIANT are passed through
- Results end up in ./out as usual, and work stuff in ./tmp